### PR TITLE
Fix import for recent Django versions

### DIFF
--- a/wagtail_feeds/models.py
+++ b/wagtail_feeds/models.py
@@ -1,5 +1,8 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 
 from wagtail.contrib.settings.models import (
     BaseSetting,


### PR DESCRIPTION
Functions such as `ugettext_lazy`, used in this project, are [deprecated since Django-3.0](https://docs.djangoproject.com/en/dev/releases/3.0/#features-deprecated-in-3-0). This simple fix imports the correct name, while still importing the old one if necessary.